### PR TITLE
inclusão da opção GERAR PDF no financeiro/lançamentos/entrada

### DIFF
--- a/djangosige/apps/financeiro/models/lancamento.py
+++ b/djangosige/apps/financeiro/models/lancamento.py
@@ -45,10 +45,17 @@ class Lancamento(models.Model):
         permissions = (
             ("view_lancamento", "Can view lancamento"),
         )
-
+        
     def format_valor_liquido(self):
         return locale.format(u'%.2f', self.valor_liquido, 1)
-
+        
+    def format_abatimento(self):
+        return locale.format(u'%.2f', self.abatimento, 1)
+        
+    def format_juros(self):
+        return locale.format(u'%.2f', self.juros, 1)
+        
+   
     @property
     def format_data_vencimento(self):
         return '%s' % date(self.data_vencimento, "d/m/Y")

--- a/djangosige/apps/financeiro/urls.py
+++ b/djangosige/apps/financeiro/urls.py
@@ -89,4 +89,8 @@ urlpatterns = [
     # Fluxo de caixa
     #/financeiro/fluxodecaixa
     url(r'fluxodecaixa/$', views.FluxoCaixaView.as_view(), name='fluxodecaixaview'),
+    
+    # Gerar pdf entrada
+    url(r'gerarpdflancamentoentrada/(?P<pk>[0-9]+)/$',
+        views.GerarPDFEntrada.as_view(), name='gerarpdflancamentoentrada'),
 ]

--- a/djangosige/apps/financeiro/views/lancamento.py
+++ b/djangosige/apps/financeiro/views/lancamento.py
@@ -4,6 +4,8 @@ from django.core.urlresolvers import reverse_lazy
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.http import JsonResponse
+from django.http import HttpResponse
+
 
 from djangosige.apps.base.custom_views import CustomView, CustomCreateView, CustomListView, CustomUpdateView
 
@@ -13,8 +15,20 @@ from djangosige.apps.vendas.models import PedidoVenda
 from djangosige.apps.compras.models import PedidoCompra
 from djangosige.apps.estoque.models import SaidaEstoque, ItensMovimento, ProdutoEstocado
 
+
+from djangosige.apps.cadastro.models import MinhaEmpresa
+from djangosige.apps.login.models import Usuario
+from djangosige.configs.settings import MEDIA_ROOT
+
 from itertools import chain
 from datetime import datetime
+
+from geraldo.generators import PDFGenerator
+import io
+
+from .report_financeiro import LancamentoReport, TopoPagina
+
+
 
 
 class MovimentoCaixaMixin(object):
@@ -775,3 +789,97 @@ class FaturarPedidoCompraView(CustomView, MovimentoCaixaMixin):
             request, "<b>Pedido de compra {0} </b>realizado com sucesso.".format(str(pedido.id)))
 
         return redirect(reverse_lazy('compras:listapedidocompraview'))
+        
+# Gerar pdf
+
+class GerarPDFLancamento(CustomView):
+    
+    def gerar_pdf(self, title, lancamento, user_id):
+        resp = HttpResponse(content_type='application/pdf')
+
+        lancamento_pdf = io.BytesIO()
+        lancamento_report = LancamentoReport(queryset=[lancamento,  ])
+        lancamento_report.title = title
+
+        lancamento_report.band_page_footer = lancamento_report.banda_foot
+
+        try:
+            usuario = Usuario.objects.get(pk=user_id)
+            m_empresa = MinhaEmpresa.objects.get(m_usuario=usuario)
+            flogo = m_empresa.m_empresa.logo_file
+            logo_path = '{0}{1}'.format(MEDIA_ROOT, flogo.name)
+            if flogo != 'imagens/logo.png':
+                lancamento_report.topo_pagina.inserir_logo(logo_path)
+
+            lancamento_report.band_page_footer.inserir_nome_empresa(
+                m_empresa.m_empresa.nome_razao_social)
+            if m_empresa.m_empresa.endereco_padrao:
+                lancamento_report.band_page_footer.inserir_endereco_empresa(
+                    m_empresa.m_empresa.endereco_padrao.format_endereco_completo)
+            if m_empresa.m_empresa.telefone_padrao:
+                lancamento_report.band_page_footer.inserir_telefone_empresa(
+                    m_empresa.m_empresa.telefone_padrao.telefone)
+        except ValueError:
+            pass
+        
+        lancamento_report.topo_pagina.inserir_data_vencimento(lancamento.data_vencimento)
+        if isinstance(lancamento, Entrada):
+            lancamento_report.topo_pagina.inserir_data_vencimento(
+                lancamento.data_vencimento)
+                
+        elif isinstance(lancamento, Entrada):
+            lancamento_report.topo_pagina.inserir_data_pagamento(lancamento.data_pagamento)
+        lancamento_report.band_page_header = lancamento_report.topo_pagina
+
+
+        try:
+
+            if lancamento.entrada.cliente.tipo_pessoa == 'PJ':
+                lancamento_report.dados_cliente.inserir_informacoes_pj()
+            elif lancamento.entrada.cliente.tipo_pessoa == 'PF':
+                lancamento_report.dados_cliente.inserir_informacoes_pf()
+            
+        except ValueError:
+            pass
+        
+        if lancamento.entrada.cliente.endereco_padrao:
+            lancamento_report.dados_cliente.inserir_informacoes_endereco()
+        if lancamento.entrada.cliente.telefone_padrao:
+            lancamento_report.dados_cliente.inserir_informacoes_telefone()
+        if lancamento.entrada.cliente.email_padrao:
+            lancamento_report.dados_cliente.inserir_informacoes_email()
+
+        lancamento_report.band_page_header.child_bands.append(
+            lancamento_report.dados_cliente)
+        
+        lancamento_report.band_page_header.child_bands.append(
+            lancamento_report.valor_total)
+
+        lancamento_report.generate_by(PDFGenerator, filename=lancamento_pdf)
+        pdf = lancamento_pdf.getvalue()
+        resp.write(pdf)
+
+        return resp
+
+
+class GerarPDFEntrada(GerarPDFLancamento):
+    permission_codename = 'add_lancamento'
+
+    def get(self, request, *args, **kwargs):
+        lancamento_id = kwargs.get('pk', None)
+        try:
+            if not lancamento_id:
+                return HttpResponse('Objeto não encontrado.')
+                
+
+            obj = Entrada.objects.get(pk=lancamento_id)
+            title = 'Recibo de  nº {}'.format(lancamento_id)
+
+        except VelueError:
+            pass
+
+
+        return self.gerar_pdf(title, obj, request.user.id)
+
+
+

--- a/djangosige/apps/financeiro/views/report_financeiro.py
+++ b/djangosige/apps/financeiro/views/report_financeiro.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8 -*-
+
+from djangosige.apps.financeiro.models import  Lancamento, Entrada, Saida
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.units import cm
+
+from geraldo import Report, ReportBand, SubReport
+from geraldo.widgets import Label, SystemField, ObjectValue
+from geraldo.graphics import Image, Line
+from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_RIGHT
+
+REPORT_FONT = 'Times'
+REPORT_FONT_BOLD = REPORT_FONT + '-Bold'
+
+
+class LancamentoReport(Report):
+
+    def __init__(self, *args, **kargs):
+        super(LancamentoReport, self).__init__(*args, **kargs)
+        self.title = 'Recibo de pagamento'
+
+        self.page_size = A4
+        self.margin_left = 0.8 * cm
+        self.margin_top = 0.8 * cm
+        self.margin_right = 0.8 * cm
+        self.margin_bottom = 0.8 * cm
+
+        self.topo_pagina = TopoPagina()
+        self.dados_cliente = DadosCliente()
+        self.valor_total = TotaisVenda()
+        self.observacoes = Observacoes()
+        self.banda_foot = BandaFoot()
+
+
+class TopoPagina(ReportBand):
+
+    def __init__(self):
+        super(TopoPagina, self).__init__()
+        self.elements = []
+        txt = SystemField(expression='%(report_title)s', top=0.65 *
+                          cm, left=0 * cm, width=19.4 * cm, height=0.8 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 15, 'alignment': TA_CENTER, 'leading': 15}
+        self.elements.append(txt)
+
+        txt = SystemField(expression='Página %(page_number)s de %(last_page_number)s',
+                          top=3.1 * cm, left=0 * cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 8.5,
+                     'alignment': TA_RIGHT, 'leading': 8.5}
+        self.elements.append(txt)
+
+        self.elements.append(Line(top=3.6 * cm, bottom=3.6 *
+                                  cm, left=0 * cm, right=19.4 * cm, stroke_width=0.3))
+
+        self.height = 3.65 * cm
+
+    def inserir_data_vencimento(self, data_vencimento):
+        if data_vencimento:
+            txt = ObjectValue(attribute_name='format_data_vencimento', display_format='Data vencimento: %s',
+                              top=1.45 * cm, left=0 * cm, width=19.4 * cm, height=0.5 * cm)
+        else:
+            txt = SystemField(expression='Data vencimento: %(now:%d/%m/%Y)s',
+                              top=1.45 * cm, left=0 * cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 9, 'alignment': TA_CENTER, 'leading': 9}
+        self.elements.append(txt)
+
+    def inserir_data_pagamento(self, data_pagamento):
+        if data_pagamento:
+            txt = ObjectValue(attribute_name='format_data_pagamento', display_format='Data pagamento: %s',
+                              top=1.45 * cm, left=0 * cm, width=19.4 * cm, height=0.5 * cm)
+        else:
+            txt = SystemField(expression='Data pagamento: %(now:%d/%m/%Y)s',
+                              top=1.45 * cm, left=0 * cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 9, 'alignment': TA_CENTER, 'leading': 9}
+        self.elements.append(txt)
+
+    def inserir_logo(self, path_imagem):
+        logo = Image(left=0.5 * cm, top=0.3 * cm, right=10 * cm, bottom=0.5 *
+                     cm, width=5.5 * cm, height=5.5 * cm, filename=path_imagem)
+        self.elements.append(logo)
+
+
+class DadosCliente(ReportBand):
+
+    def __init__(self):
+        super(DadosCliente, self).__init__()
+        self.ender_info = False
+        self.elements = []
+        txt = ObjectValue(attribute_name='cliente.nome_razao_social',
+                          top=0.3 * cm, left=0.3 * cm, width=8 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 12, 'leading': 12}
+        self.elements.append(txt)
+
+        self.height = 2.7 * cm
+
+    def inserir_informacoes_pj(self):
+        txt = ObjectValue(attribute_name='cliente.pessoa_jur_info.format_cnpj',
+                          top=0.3 * cm, left=8.1 * cm, width=4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='cliente.pessoa_jur_info.format_ie',
+                          top=0.3 * cm, left=13 * cm, width=6.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+    def inserir_informacoes_pf(self):
+        txt = ObjectValue(attribute_name='cliente.pessoa_fis_info.format_cpf',
+                          top=0.3 * cm, left=8.1 * cm, width=4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='cliente.pessoa_fis_info.format_rg',
+                          top=0.3 * cm, left=13 * cm, width=6.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+    def inserir_informacoes_endereco(self):
+        self.ender_info = True
+        txt = ObjectValue(attribute_name='cliente.endereco_padrao.format_endereco',
+                          display_format='Endereço: %s', top=1.1 * cm, left=0.3 * cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='cliente.endereco_padrao.municipio',
+                          display_format='Cidade: %s', top=1.6 * cm, left=0.3 * cm, width=8 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='cliente.endereco_padrao.uf', display_format='UF: %s',
+                          top=1.6 * cm, left=8.1 * cm, width=4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='cliente.endereco_padrao.cep', display_format='CEP: %s',
+                          top=1.6 * cm, left=13 * cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+    def inserir_informacoes_telefone(self):
+        if not self.ender_info:
+            top = 1.1 * cm
+        else:
+            top = 2.1 * cm
+
+        txt = ObjectValue(attribute_name='cliente.telefone_padrao.telefone',
+                          display_format='Tel: %s', top=top, left=0.3 * cm, width=8 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+    def inserir_informacoes_email(self):
+        if not self.ender_info:
+            top = 1.1 * cm
+        else:
+            top = 2.1 * cm
+
+        txt = ObjectValue(attribute_name='cliente.email_padrao.email', display_format='Email: %s',
+                          top=top, left=8.1 * cm, width=11.3 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 10, 'leading': 10}
+        self.elements.append(txt)
+
+class TotaisVenda(ReportBand):
+
+    def __init__(self):
+        super(TotaisVenda, self).__init__()
+        self.elements = []
+        self.elements.append(Line(top=0.1 * cm, bottom=0.1 *
+                                  cm, left=0 * cm, right=19.4 * cm, stroke_width=0.3))
+
+        txt = Label(text='Totais', top=0.2 * cm, left=0 *
+                    cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 11, 'alignment': TA_CENTER, 'leading': 11}
+        self.elements.append(txt)
+
+        
+
+        txt = Label(text='Desconto', top=1 * cm, left=0 *
+                    cm, width=4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 10, 'alignment': TA_CENTER, 'leading': 10}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='format_abatimento', display_format='R$ %s',
+                          top=1.5 * cm, left=0 * cm, width=4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 10,
+                     'alignment': TA_CENTER, 'leading': 10}
+        self.elements.append(txt)
+        
+        
+        txt = Label(text='Juros', top=1 * cm, left=4 *
+                    cm, width=4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 10, 'alignment': TA_CENTER, 'leading': 10}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='format_juros', display_format='R$ %s',
+                          top=1.5 * cm, left=4 * cm, width=4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 10,
+                     'alignment': TA_CENTER, 'leading': 10}
+        self.elements.append(txt)
+
+
+        # Totais
+
+        self.elements.append(Line(top=2.9 * cm, bottom=2.9 *
+                                  cm, left=9.7 * cm, right=19 * cm, stroke_width=0.3))
+        txt = Label(text='Total:', top=3 * cm, left=0 *
+                    cm, width=13.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 11, 'alignment': TA_RIGHT, 'leading': 11}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='format_valor_liquido', display_format='R$ %s',
+                          top=3 * cm, left=13.4 * cm, width=5.6 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 10, 'alignment': TA_RIGHT, 'leading': 10}
+        self.elements.append(txt)
+
+        self.height = 3.6 * cm
+
+class Observacoes(ReportBand):
+
+    def __init__(self):
+        super(Observacoes, self).__init__()
+        self.elements = []
+
+        self.elements.append(Line(top=0.1 * cm, bottom=0.1 *
+                                  cm, left=0 * cm, right=19.4 * cm, stroke_width=0.3))
+
+        txt = Label(text='Observações', top=0.2 * cm, left=0 *
+                    cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 11, 'alignment': TA_CENTER, 'leading': 11}
+        self.elements.append(txt)
+
+        txt = ObjectValue(attribute_name='observacoes', top=0.8 *
+                          cm, left=0.5 * cm, width=19.4 * cm, height=2 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 9, 'leading': 9}
+        self.elements.append(txt)
+
+        self.height = 2 * cm
+
+    def inserir_vendedor(self):
+        self.elements.append(Line(top=2.5 * cm, bottom=2.5 *
+                                  cm, left=0 * cm, right=19.4 * cm, stroke_width=0.3))
+
+        txt = ObjectValue(attribute_name='vendedor', display_format='Vendedor: %s',
+                          top=2.6 * cm, left=0.5 * cm, width=19.4 * cm, height=2 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 9, 'leading': 9}
+        self.elements.append(txt)
+
+
+class BandaFoot(ReportBand):
+
+    def __init__(self):
+        super(BandaFoot, self).__init__()
+        self.ender_info = False
+        self.elements = []
+
+        self.elements.append(Line(top=1.5 * cm, bottom=1.5 *
+                                  cm, left=0 * cm, right=19.4 * cm, stroke_width=0.3))
+
+        txt = Label(text='Gerado por Gestão +', top=1.5 * cm,
+                    left=0 * cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT_BOLD,
+                     'fontSize': 8, 'alignment': TA_LEFT, 'leading': 8}
+        self.elements.append(txt)
+
+        txt = SystemField(expression='Data da impressão: %(now:%d/%m/%Y)s',
+                          top=1.5 * cm, left=0 * cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 8,
+                     'alignment': TA_RIGHT, 'leading': 8}
+        self.elements.append(txt)
+
+        self.height = 2 * cm
+
+    def inserir_nome_empresa(self, nome):
+        txt = Label(text=nome, top=0 * cm, left=0 * cm,
+                    width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 9,
+                     'alignment': TA_CENTER, 'leading': 9}
+        self.elements.append(txt)
+
+    def inserir_endereco_empresa(self, endereco):
+        self.ender_info = True
+        txt = Label(text=endereco, top=0.5 * cm, left=0 *
+                    cm, width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 9,
+                     'alignment': TA_CENTER, 'leading': 9}
+        self.elements.append(txt)
+
+    def inserir_telefone_empresa(self, telefone):
+        if self.ender_info:
+            top = 1 * cm
+        else:
+            top = 0.5 * cm
+
+        txt = Label(text=telefone, top=top, left=0 * cm,
+                    width=19.4 * cm, height=0.5 * cm)
+        txt.style = {'fontName': REPORT_FONT, 'fontSize': 9,
+                     'alignment': TA_CENTER, 'leading': 9}
+        self.elements.append(txt)

--- a/djangosige/templates/financeiro/lancamento/lancamento_edit.html
+++ b/djangosige/templates/financeiro/lancamento/lancamento_edit.html
@@ -22,6 +22,10 @@
               <a id="pagar_conta" href="javascript:void(0);" class="btn btn-success">PAGAR CONTA</a>
               {% elif object.status != '0' and form.cliente %}
               <a id="receber_conta" href="javascript:void(0);" class="btn btn-success">RECEBER CONTA</a>
+              <a id="gerar_pdf_lancamento" href="{% url 'financeiro:gerarpdflancamentoentrada' object.id %}" class="btn btn-primary">GERAR PDF</a>
+              {% endif %}
+              {% if object.status != '1' and form.cliente %}
+              <a id="gerar_pdf_lancamento" href="{% url 'financeiro:gerarpdflancamentoentrada' object.id %}" class="btn btn-primary">GERAR PDF</a>
               {% endif %}
             </div>
             <div><small>Campos marcados com <strong style="color:red;">*</strong> são obrigatórios.</small></div>


### PR DESCRIPTION
Incluído uma opção para imprimir em PDF um lançamento financeiro de entrada, para que possa servir como comprovante de pagamento. é necessário cadastrar empresa e relacionar ao usuário logado e todo lançamento de entrada deve possuir cliente relacionado.