### PR TITLE
fix(security): protege views AJAX Info* com CheckPermissionMixin (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ### Fixed
 
+- **Segurança: 8 views AJAX `Info*` passavam pelo Django sem checagem
+  de permissão (#143, HIGH).** `InfoCliente`, `InfoFornecedor`,
+  `InfoEmpresa`, `InfoTransportadora`, `InfoProduto`, `InfoVenda`,
+  `InfoCompra` e `InfoCondicaoPagamento` herdavam de
+  `django.views.generic.View` em vez de `CustomView`, bypassando o
+  `CheckPermissionMixin`. Qualquer usuário autenticado conseguia ler
+  dados sensíveis (CPF, CNPJ, RG, endereços, preços, condições de
+  pagamento) só com o id do registro. Cada view agora herda de
+  `CustomView` e exige a permissão `view_<modelo>` correspondente.
+  Regressão coberta por `djangosige/tests/test_security_ajax_views.py`
+  (8 testes). Demais achados da issue (state-changing via GET,
+  bulk-delete sem ownership check) seguem em aberto.
 - **Importação de NF-e v4.0 quebrava com `NOT NULL constraint failed:
   fiscal_notafiscal.dhemi` (#122).** Quando o XML não trazia `<dhEmi>`
   legível, o `pysignfe` devolvia `None` para `nfe.infNFe.ide.dhEmi.valor`

--- a/djangosige/apps/cadastro/views/ajax_views.py
+++ b/djangosige/apps/cadastro/views/ajax_views.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from django.views.generic import View
 from django.http import HttpResponse
 from django.core import serializers
 
+from djangosige.apps.base.custom_views import CustomView
 from djangosige.apps.cadastro.models import Pessoa, Cliente, Fornecedor, Transportadora, Produto
 from djangosige.apps.fiscal.models import ICMS, ICMSSN, IPI, ICMSUFDest
 
 
-class InfoCliente(View):
+class InfoCliente(CustomView):
+    permission_codename = 'view_cliente'
 
     def post(self, request, *args, **kwargs):
         obj_list = []
@@ -34,7 +35,8 @@ class InfoCliente(View):
         return HttpResponse(data, content_type='application/json')
 
 
-class InfoFornecedor(View):
+class InfoFornecedor(CustomView):
+    permission_codename = 'view_fornecedor'
 
     def post(self, request, *args, **kwargs):
         obj_list = []
@@ -60,7 +62,8 @@ class InfoFornecedor(View):
         return HttpResponse(data, content_type='application/json')
 
 
-class InfoEmpresa(View):
+class InfoEmpresa(CustomView):
+    permission_codename = 'view_empresa'
 
     def post(self, request, *args, **kwargs):
         pessoa = Pessoa.objects.get(pk=request.POST['pessoaId'])
@@ -76,7 +79,8 @@ class InfoEmpresa(View):
         return HttpResponse(data, content_type='application/json')
 
 
-class InfoTransportadora(View):
+class InfoTransportadora(CustomView):
+    permission_codename = 'view_transportadora'
 
     def post(self, request, *args, **kwargs):
         veiculos = Transportadora.objects.get(
@@ -87,7 +91,8 @@ class InfoTransportadora(View):
         return HttpResponse(data, content_type='application/json')
 
 
-class InfoProduto(View):
+class InfoProduto(CustomView):
+    permission_codename = 'view_produto'
 
     def post(self, request, *args, **kwargs):
         obj_list = []

--- a/djangosige/apps/compras/views/ajax_views.py
+++ b/djangosige/apps/compras/views/ajax_views.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from django.views.generic import View
 from django.http import HttpResponse
 
 import json
 
+from djangosige.apps.base.custom_views import CustomView
 from djangosige.apps.compras.models import PedidoCompra
 
 
-class InfoCompra(View):
+class InfoCompra(CustomView):
+    permission_codename = 'view_pedidocompra'
 
     def post(self, request, *args, **kwargs):
         compra = PedidoCompra.objects.get(pk=request.POST['compraId'])

--- a/djangosige/apps/vendas/views/ajax_views.py
+++ b/djangosige/apps/vendas/views/ajax_views.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from django.views.generic import View
 from django.http import HttpResponse
 
 import json
 
+from djangosige.apps.base.custom_views import CustomView
 from djangosige.apps.vendas.models import PedidoVenda
 
 
-class InfoVenda(View):
+class InfoVenda(CustomView):
+    permission_codename = 'view_pedidovenda'
 
     def post(self, request, *args, **kwargs):
         venda = PedidoVenda.objects.get(pk=request.POST['vendaId'])

--- a/djangosige/apps/vendas/views/pagamento.py
+++ b/djangosige/apps/vendas/views/pagamento.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from django.urls import reverse_lazy
-from django.views.generic import View
 from django.http import HttpResponse
 from django.core import serializers
 
-from djangosige.apps.base.custom_views import CustomCreateView, CustomListView, CustomUpdateView
+from djangosige.apps.base.custom_views import CustomCreateView, CustomListView, CustomUpdateView, CustomView
 
 from djangosige.apps.vendas.forms import CondicaoPagamentoForm
 from djangosige.apps.vendas.models import CondicaoPagamento
@@ -64,7 +63,8 @@ class EditarCondicaoPagamentoView(CustomUpdateView):
         return context
 
 
-class InfoCondicaoPagamento(View):
+class InfoCondicaoPagamento(CustomView):
+    permission_codename = 'view_condicaopagamento'
 
     def post(self, request, *args, **kwargs):
         pag = CondicaoPagamento.objects.get(pk=request.POST['pagamentoId'])

--- a/djangosige/tests/test_security_ajax_views.py
+++ b/djangosige/tests/test_security_ajax_views.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+Regressão para o issue #143 — Security Audit.
+
+Antes do fix, as 8 views Info* (que retornam JSON de cliente, fornecedor,
+empresa, transportadora, produto, venda, compra e condição de pagamento)
+herdavam de `django.views.generic.View` em vez de `CustomView`, o que
+fazia elas ignorarem por completo o `CheckPermissionMixin`. Qualquer
+usuário autenticado conseguia ler dados sensíveis (CPF, CNPJ, RG,
+endereços, preços, etc.) sem ter a permissão `view_<modelo>`.
+
+O fix muda a herança para `CustomView` e define `permission_codename`
+em cada uma. Este arquivo confirma que usuários sem a permissão
+correspondente são bloqueados.
+"""
+
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+
+from djangosige.tests.test_case import BaseTestCase, TEST_USERNAME, TEST_PASSWORD
+
+
+class InfoViewsExigemPermissaoTestCase(BaseTestCase):
+    """Cada Info* deve redirecionar com `permission_warning` quando
+    o usuário autenticado não tem `view_<modelo>`."""
+
+    def _post_sem_permissao(self, url, post_data, codename):
+        # Remove a permissão específica, sai do superuser e re-loga.
+        self.user.is_superuser = False
+        perm = Permission.objects.get(codename=codename)
+        self.user.user_permissions.remove(perm)
+        self.user.save()
+        self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
+
+        response = self.client.post(url, post_data, follow=True)
+        try:
+            message_tags = " ".join(
+                str(m.tags) for m in list(response.context['messages']))
+            self.assertIn("permission_warning", message_tags)
+        finally:
+            # Restaura superuser para não contaminar outros testes.
+            self.user.is_superuser = True
+            self.user.save()
+            self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
+
+    def test_info_cliente_bloqueia_sem_view_cliente(self):
+        url = reverse('cadastro:infocliente')
+        self._post_sem_permissao(url, {'pessoaId': 1}, 'view_cliente')
+
+    def test_info_fornecedor_bloqueia_sem_view_fornecedor(self):
+        url = reverse('cadastro:infofornecedor')
+        self._post_sem_permissao(url, {'pessoaId': 1}, 'view_fornecedor')
+
+    def test_info_empresa_bloqueia_sem_view_empresa(self):
+        url = reverse('cadastro:infoempresa')
+        self._post_sem_permissao(url, {'pessoaId': 1}, 'view_empresa')
+
+    def test_info_transportadora_bloqueia_sem_view_transportadora(self):
+        url = reverse('cadastro:infotransportadora')
+        self._post_sem_permissao(
+            url, {'transportadoraId': 1}, 'view_transportadora')
+
+    def test_info_produto_bloqueia_sem_view_produto(self):
+        url = reverse('cadastro:infoproduto')
+        self._post_sem_permissao(url, {'produtoId': 1}, 'view_produto')
+
+    def test_info_venda_bloqueia_sem_view_pedidovenda(self):
+        url = reverse('vendas:infovenda')
+        self._post_sem_permissao(url, {'vendaId': 1}, 'view_pedidovenda')
+
+    def test_info_compra_bloqueia_sem_view_pedidocompra(self):
+        url = reverse('compras:infocompra')
+        self._post_sem_permissao(url, {'compraId': 1}, 'view_pedidocompra')
+
+    def test_info_condicao_pagamento_bloqueia_sem_view_condicaopagamento(self):
+        url = reverse('vendas:infocondpagamento')
+        self._post_sem_permissao(
+            url, {'pagamentoId': 1}, 'view_condicaopagamento')


### PR DESCRIPTION
Issue #143 (HIGH): as 8 views AJAX `Info*` herdavam de `django.views.generic.View` em vez de `CustomView`, o que fazia elas ignorarem o `CheckPermissionMixin`. Qualquer usuário autenticado conseguia POSTar para essas URLs e receber JSON com dados sensíveis (CPF, CNPJ, RG, endereços, preços, condições de pagamento) só com o id do registro — sem precisar das permissões `view_<modelo>`.

Views afetadas:

- `InfoCliente` → permission_codename = 'view_cliente'
- `InfoFornecedor` → 'view_fornecedor'
- `InfoEmpresa` → 'view_empresa'
- `InfoTransportadora` → 'view_transportadora'
- `InfoProduto` → 'view_produto'
- `InfoVenda` → 'view_pedidovenda'
- `InfoCompra` → 'view_pedidocompra'
- `InfoCondicaoPagamento` → 'view_condicaopagamento'

Testes de regressão em `djangosige/tests/test_security_ajax_views.py` (8 testes — um por view) verificam que usuários sem a permissão correspondente recebem o redirect com `permission_warning` em vez do JSON.

Demais achados da issue (state-changing via GET, bulk-delete sem ownership check, PII excessivo nas respostas, user enumeration no reset de senha) seguem em aberto e serão tratados em commits separados.

CHANGELOG atualizado em "Unreleased > Fixed".