### PR TITLE
refactor (#151): desacoplar importações de configuração usando django.conf.settings

### DIFF
--- a/djangosige/apps/base/urls.py
+++ b/djangosige/apps/base/urls.py
@@ -3,14 +3,14 @@
 from django.urls import re_path as url
 from . import views
 
-from djangosige.configs import DEBUG
+from django.conf import settings
 
 app_name = 'base'
 urlpatterns = [
     url(r'^$', views.IndexView.as_view(), name='index'),
 ]
 
-if DEBUG:
+if settings.DEBUG:
     urlpatterns += [
         url(r'^404/$', views.handler404),
         url(r'^500/$', views.handler500),

--- a/djangosige/apps/cadastro/models/empresa.py
+++ b/djangosige/apps/cadastro/models/empresa.py
@@ -8,7 +8,7 @@ from django.dispatch import receiver
 
 from .base import Pessoa
 from djangosige.apps.login.models import Usuario
-from djangosige.configs.settings import MEDIA_ROOT
+from django.conf import settings
 
 
 def logo_directory_path(instance, filename):
@@ -28,7 +28,7 @@ class Empresa(Pessoa):
     @property
     def caminho_completo_logo(self):
         if self.logo_file.name != 'imagens/logo.png':
-            return os.path.join(MEDIA_ROOT, self.logo_file.name)
+            return os.path.join(settings.MEDIA_ROOT, self.logo_file.name)
         else:
             return ''
 

--- a/djangosige/apps/compras/views/compras.py
+++ b/djangosige/apps/compras/views/compras.py
@@ -15,7 +15,7 @@ from djangosige.apps.compras.models import OrcamentoCompra, PedidoCompra, ItensC
 from djangosige.apps.cadastro.models import MinhaEmpresa
 from djangosige.apps.estoque.models import ProdutoEstocado, EntradaEstoque, ItensMovimento
 from djangosige.apps.login.models import Usuario
-from djangosige.configs.settings import MEDIA_ROOT
+from django.conf import settings
 
 from datetime import datetime
 from pathlib import Path
@@ -523,7 +523,7 @@ class GerarPDFCompra(CustomView):
                 empresa_info['telefone'] = empresa.telefone_padrao.telefone
             flogo = empresa.logo_file
             if flogo and flogo.name != 'imagens/logo.png':
-                candidato = Path(MEDIA_ROOT) / flogo.name
+                candidato = Path(settings.MEDIA_ROOT) / flogo.name
                 if candidato.exists():
                     logo_path = candidato.as_uri()
         except (Usuario.DoesNotExist, MinhaEmpresa.DoesNotExist):
@@ -547,7 +547,7 @@ class GerarPDFCompra(CustomView):
             'hoje': timezone.now(),
         }
         html_string = render_to_string('base/pdf/relatorio_documento.html', context)
-        pdf_bytes = HTML(string=html_string, base_url=MEDIA_ROOT).write_pdf()
+        pdf_bytes = HTML(string=html_string, base_url=settings.MEDIA_ROOT).write_pdf()
 
         resp = HttpResponse(pdf_bytes, content_type='application/pdf')
         return resp

--- a/djangosige/apps/fiscal/models/nota_fiscal.py
+++ b/djangosige/apps/fiscal/models/nota_fiscal.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 import os
 import re
 
-from djangosige.configs.settings import MEDIA_ROOT, APP_ROOT
+from django.conf import settings
 
 
 IND_PAG_ESCOLHAS = (
@@ -161,10 +161,10 @@ class NotaFiscal(models.Model):
     @property
     def caminho_proc_completo(self):
         if self.arquivo_proc:
-            if APP_ROOT in self.arquivo_proc.name:
+            if settings.APP_ROOT in self.arquivo_proc.name:
                 return self.arquivo_proc.name
             else:
-                return os.path.join(APP_ROOT, self.arquivo_proc.url)
+                return os.path.join(settings.APP_ROOT, self.arquivo_proc.url)
         else:
             return ''
 
@@ -303,7 +303,7 @@ class ConfiguracaoNotaFiscal(models.Model):
             return True
 
     def get_certificado_a1(self):
-        return os.path.join(MEDIA_ROOT, self.arquivo_certificado_a1.name)
+        return os.path.join(settings.MEDIA_ROOT, self.arquivo_certificado_a1.name)
 
 
 class ErrosValidacaoNotaFiscal(models.Model):

--- a/djangosige/apps/fiscal/views/processador_nf.py
+++ b/djangosige/apps/fiscal/views/processador_nf.py
@@ -3,7 +3,7 @@
 from djangosige.apps.fiscal.models import NotaFiscalSaida, NotaFiscalEntrada, ConfiguracaoNotaFiscal, AutXML, \
     ErrosValidacaoNotaFiscal, RespostaSefazNotaFiscal, NaturezaOperacao, GrupoFiscal, \
     ICMS, ICMSUFDest, ICMSSN, IPI, PIS, COFINS
-from djangosige.configs.settings import MEDIA_ROOT
+from django.conf import settings
 from djangosige.apps.cadastro.models import COD_UF, PessoaJuridica, PessoaFisica, Fornecedor, Cliente, Empresa, Transportadora, Endereco, Telefone, Produto, Unidade
 from djangosige.apps.compras.models import PedidoCompra, ItensCompra
 from djangosige.apps.vendas.models import PedidoVenda, ItensVenda
@@ -1188,7 +1188,7 @@ class ProcessadorNotaFiscal(object):
             return self.salvar_mensagem(message=e.descricao, erro=True)
         else:
             processo = self.nova_nfe.gerar_xml(xml_nfe=nfe.xml, cert=self.info_certificado['cert'], key=self.info_certificado['key'],
-                                               versao=nota_obj.versao, ambiente=int(nota_obj.tp_amb), estado=nota_obj.estado, consumidor=nota_obj.consumidor, caminho=MEDIA_ROOT)
+                                               versao=nota_obj.versao, ambiente=int(nota_obj.tp_amb), estado=nota_obj.estado, consumidor=nota_obj.consumidor, caminho=settings.MEDIA_ROOT)
         temp_list = []
         for err in processo.envio.erros:
             e = ErrosValidacaoNotaFiscal(nfe=nota_obj)
@@ -1256,7 +1256,7 @@ class ProcessadorNotaFiscal(object):
             try:
                 processos = self.nova_nfe.processar_nota(xml_nfe=nfe.xml, cert=self.info_certificado['cert'], key=self.info_certificado['key'],
                                                          versao=nota_obj.versao, ambiente=int(nota_obj.tp_amb), estado=nota_obj.estado, consumidor=nota_obj.consumidor, contingencia=nota_obj.contingencia,
-                                                         consultar_servico=False, numero_lote=nota_obj.numero_lote, caminho=MEDIA_ROOT)
+                                                         consultar_servico=False, numero_lote=nota_obj.numero_lote, caminho=settings.MEDIA_ROOT)
 
                 # HTTP 200 - OK
                 if processos['lote'].resposta.status in (u'200', 200):
@@ -1401,7 +1401,7 @@ class ProcessadorNotaFiscal(object):
         else:
             try:
                 processo = self.nova_nfe.cancelar_nota(chave=nota_obj.chave, protocolo=nota_obj.numero_protocolo, justificativa=nota_obj.just_canc, cert=self.info_certificado['cert'], key=self.info_certificado['key'],
-                                                       versao=nota_obj.versao, ambiente=int(nota_obj.tp_amb), estado=nota_obj.estado, contingencia=nota_obj.contingencia, caminho=MEDIA_ROOT)
+                                                       versao=nota_obj.versao, ambiente=int(nota_obj.tp_amb), estado=nota_obj.estado, contingencia=nota_obj.contingencia, caminho=settings.MEDIA_ROOT)
 
                 # HTTP 200 - OK
                 if processo.resposta.status in (u'200', 200):
@@ -1531,7 +1531,7 @@ class ProcessadorNotaFiscal(object):
         else:
             try:
                 processo = self.nova_nfe.consultar_cadastro(cert=self.info_certificado['cert'], key=self.info_certificado['key'], cpf_cnpj=empresa.cpf_cnpj_apenas_digitos, versao=u'4.00',
-                                                            ambiente=2, estado=empresa.uf_padrao, contingencia=False, salvar_arquivos=salvar_arquivos, caminho=MEDIA_ROOT)
+                                                            ambiente=2, estado=empresa.uf_padrao, contingencia=False, salvar_arquivos=salvar_arquivos, caminho=settings.MEDIA_ROOT)
 
                 self.processo = processo
 
@@ -1564,7 +1564,7 @@ class ProcessadorNotaFiscal(object):
             return self.salvar_mensagem(message=u'CNPJ do emitente não foi preenchido.', erro=True)
         else:
             processo = self.nova_nfe.inutilizar_faixa_numeracao(cnpj=empresa.cpf_cnpj_apenas_digitos, serie=serie, numero_inicial=numero_inicial, numero_final=numero_final, justificativa=justificativa,
-                                                                cert=self.info_certificado['cert'], key=self.info_certificado['key'], versao=u'4.00', ambiente=int(ambiente), estado=empresa.uf_padrao, nfce=nfce, contingencia=False, caminho=MEDIA_ROOT)
+                                                                cert=self.info_certificado['cert'], key=self.info_certificado['key'], versao=u'4.00', ambiente=int(ambiente), estado=empresa.uf_padrao, nfce=nfce, contingencia=False, caminho=settings.MEDIA_ROOT)
 
             self.processo = processo
 
@@ -1589,7 +1589,7 @@ class ProcessadorNotaFiscal(object):
             return self.salvar_mensagem(message=u'Chave com código da UF incorreto.', erro=True)
 
         processo = self.nova_nfe.consultar_nfe(chave=chave, cert=self.info_certificado['cert'], key=self.info_certificado['key'], versao=u'4.00', ambiente=int(
-            ambiente), estado=uf, contingencia=False, caminho=MEDIA_ROOT)
+            ambiente), estado=uf, contingencia=False, caminho=settings.MEDIA_ROOT)
 
         self.processo = processo
 
@@ -1616,7 +1616,7 @@ class ProcessadorNotaFiscal(object):
         cnpj = chave[6:20]
 
         processo = self.nova_nfe.download_notas(cnpj=cnpj, lista_chaves=[chave, ], ambiente_nacional=ambiente_nacional, cert=self.info_certificado['cert'], key=self.info_certificado['key'],
-                                                versao=u'4.00', ambiente=int(ambiente), estado=uf, contingencia=False, caminho=MEDIA_ROOT)
+                                                versao=u'4.00', ambiente=int(ambiente), estado=uf, contingencia=False, caminho=settings.MEDIA_ROOT)
 
         self.processo = processo
 
@@ -1641,7 +1641,7 @@ class ProcessadorNotaFiscal(object):
             return self.salvar_mensagem(message=u'Chave com código da UF incorreto.', erro=True)
 
         processo = self.nova_nfe.efetuar_manifesto(cnpj=cnpj, tipo_manifesto=tipo_manifesto, chave=chave, ambiente_nacional=ambiente_nacional, cert=self.info_certificado['cert'], key=self.info_certificado['key'], versao=u'4.00',
-                                                   ambiente=int(ambiente), estado=uf, contingencia=False, caminho=MEDIA_ROOT)
+                                                   ambiente=int(ambiente), estado=uf, contingencia=False, caminho=settings.MEDIA_ROOT)
 
         self.processo = processo
 

--- a/djangosige/apps/login/views.py
+++ b/djangosige/apps/login/views.py
@@ -24,7 +24,8 @@ from djangosige.apps.base.views_mixins import SuperUserRequiredMixin
 
 from .forms import UserLoginForm, UserRegistrationForm, PasswordResetForm, SetPasswordForm, PerfilUsuarioForm
 from .models import Usuario
-from djangosige.configs.settings import DEFAULT_FROM_EMAIL
+from django.conf import settings
+
 
 from djangosige.apps.cadastro.forms import MinhaEmpresaForm
 from djangosige.apps.cadastro.models import MinhaEmpresa
@@ -114,7 +115,7 @@ class ForgotPasswordView(FormView):
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.POST)
 
-        if not DEFAULT_FROM_EMAIL:
+        if not settings.DEFAULT_FROM_EMAIL:
             form.add_error(
                 field=None, error=u"Envio de email não configurado.")
             return self.form_invalid(form)
@@ -140,7 +141,7 @@ class ForgotPasswordView(FormView):
                         email_template_name = 'login/trocar_senha_email.html'
                         email_mensagem = loader.render_to_string(
                             email_template_name, c)
-                        sended = send_mail(subject, email_mensagem, DEFAULT_FROM_EMAIL, [
+                        sended = send_mail(subject, email_mensagem, settings.DEFAULT_FROM_EMAIL, [
                                            associated_user.email, ], fail_silently=False)
 
                         if sended == 1:

--- a/djangosige/apps/vendas/views/vendas.py
+++ b/djangosige/apps/vendas/views/vendas.py
@@ -13,7 +13,7 @@ from djangosige.apps.vendas.forms import OrcamentoVendaForm, PedidoVendaForm, It
 from djangosige.apps.vendas.models import OrcamentoVenda, PedidoVenda, ItensVenda, Pagamento
 from djangosige.apps.cadastro.models import MinhaEmpresa
 from djangosige.apps.login.models import Usuario
-from djangosige.configs.settings import MEDIA_ROOT
+from django.conf import settings
 
 from datetime import datetime
 from pathlib import Path
@@ -457,7 +457,7 @@ class GerarPDFVenda(CustomView):
                 empresa_info['telefone'] = empresa.telefone_padrao.telefone
             flogo = empresa.logo_file
             if flogo and flogo.name != 'imagens/logo.png':
-                candidato = Path(MEDIA_ROOT) / flogo.name
+                candidato = Path(settings.MEDIA_ROOT) / flogo.name
                 if candidato.exists():
                     logo_path = candidato.as_uri()
         except (Usuario.DoesNotExist, MinhaEmpresa.DoesNotExist):
@@ -481,7 +481,7 @@ class GerarPDFVenda(CustomView):
             'hoje': timezone.now(),
         }
         html_string = render_to_string('base/pdf/relatorio_documento.html', context)
-        pdf_bytes = HTML(string=html_string, base_url=MEDIA_ROOT).write_pdf()
+        pdf_bytes = HTML(string=html_string, base_url=settings.MEDIA_ROOT).write_pdf()
 
         resp = HttpResponse(pdf_bytes, content_type='application/pdf')
         return resp

--- a/djangosige/tests/base/test_views.py
+++ b/djangosige/tests/base/test_views.py
@@ -3,7 +3,7 @@
 from djangosige.tests.test_case import BaseTestCase
 from django.urls import resolve, reverse
 from djangosige.apps.base.views import IndexView
-from djangosige.configs import DEBUG
+from django.conf import settings
 
 
 class BaseViewsTestCase(BaseTestCase):
@@ -27,7 +27,7 @@ class BaseViewsTestCase(BaseTestCase):
         response = self.client.get("/500/")
         # Se DEBUG=True temos views personalizadas,
         # caso contrário /500/ retornar 404
-        if DEBUG:
+        if settings.DEBUG:
             self.assertTemplateUsed(response, '500.html')
             self.assertEqual(response.status_code, 500)
         else:

--- a/djangosige/urls.py
+++ b/djangosige/urls.py
@@ -3,7 +3,7 @@
 from django.urls import re_path as url, include
 from django.contrib import admin
 from django.conf.urls.static import static
-from .configs.settings import DEBUG, MEDIA_ROOT, MEDIA_URL
+from django.conf import settings
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
@@ -17,5 +17,5 @@ urlpatterns = [
     url(r'^estoque/', include('djangosige.apps.estoque.urls')),
 ]
 
-if DEBUG is True:
-    urlpatterns += static(MEDIA_URL, document_root=MEDIA_ROOT)
+if settings.DEBUG is True:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## O que foi feito?

Substituição das importações diretas do arquivo físico `djangosige.configs.settings` pelo objeto dinâmico e global `settings` do próprio Django (`from django.conf import settings`) em todos os módulos mapeados.

## Motivação

Garantir a flexibilidade do projeto para alternar entre diferentes ambientes (como desenvolvimento, testes e produção) via `DJANGO_SETTINGS_MODULE`, além de mitigar riscos de importações circulares e seguir as boas práticas oficiais do framework.