### PR TITLE
fix(base): corrigir assinatura e simplificar os handlers 404 e 500

### DIFF
--- a/djangosige/apps/base/views.py
+++ b/djangosige/apps/base/views.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from http import HTTPStatus
+
+from django.http import HttpRequest, HttpResponse
 from django.views.generic import TemplateView
 from django.shortcuts import render
 from django.core.exceptions import ObjectDoesNotExist
@@ -78,13 +81,11 @@ class IndexView(TemplateView):
         return context
 
 
-def handler404(request):
-    response = render(request, '404.html', {})
-    response.status_code = 404
-    return response
+def handler404(request: HttpRequest, exception=None) -> HttpResponse:
+    """Handler personalizado para erro 404 (Not Found) com argumento de exceção obrigatório."""
+    return render(request, '404.html', status=HTTPStatus.NOT_FOUND)
 
 
-def handler500(request):
-    response = render(request, '500.html', {})
-    response.status_code = 500
-    return response
+def handler500(request: HttpRequest) -> HttpResponse:
+    """Handler personalizado para erro 500 (Internal Server Error)."""
+    return render(request, '500.html', status=HTTPStatus.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Este Pull Request resolve as inconsistências na declaração dos visualizadores de erro do sistema mapeados na Issue #156, garantindo compatibilidade com o ecossistema moderno do Django e simplificando o retorno HTTP.

## Alterações Realizadas
- **Correção de Assinatura (Bugfix):** Adicionado o parâmetro `exception=None` ao `handler404`. Sem este argumento, o Django gera um erro de execução (*TypeError*) ao tentar redirecionar o usuário para a página de erro 404.
- **Simplificação de Código:** Substituída a atribuição manual de `response.status_code` pelo uso direto do parâmetro `status` da função `render()`, reduzindo o boilerplate de código.
- **Limpeza de Parâmetros:** Removidos dicionários de contexto vazios (`{}`) que não tinham utilidade prática nas páginas de erro globais.

## Impacto no Projeto
Previne falhas inesperadas em ambiente de produção (com `DEBUG=False`) ao disparar telas de erro e padroniza as respostas HTTP seguindo as convenções nativas do framework.

## Links Relacionados
- Resolve: #156